### PR TITLE
Fix a 404 on a link to the WPE site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # WPE Webkit for the RaspberryPi
 
 This project provides an easy way of running [WPE
-Webkit](https://webkit.org/wpe/) for the RaspberryPi. WPEWebkit is a full
+Webkit](https://webkit.org/wpe/) for the Raspberry Pi. WPEWebkit is a full
 featured browser that takes advantage of the GPU to provide hardware
 accelerated CSS, WebGL, and HTML5 video.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # WPE Webkit for the RaspberryPi
 
 This project provides an easy way of running [WPE
-Webkit](https://www.igalia.com/wpe/) for the RaspberryPi. WPEWebkit is a full
+Webkit](https://webkit.org/wpe/) for the RaspberryPi. WPEWebkit is a full
 featured browser that takes advantage of the GPU to provide hardware
 accelerated CSS, WebGL, and HTML5 video.
 


### PR DESCRIPTION
Looks like it's not living at Igalia anymore - but there's a new nice page under webkit.org